### PR TITLE
remove unused query option

### DIFF
--- a/deploy/spin/docker/tiled/static/login.html
+++ b/deploy/spin/docker/tiled/static/login.html
@@ -58,7 +58,7 @@ $(document).ready(function() {
     }
   }else{
   //  $("#login").attr("href",orcidAuthUrl+"?response_type=code&redirect_uri=https%3A%2F%2Faimm.lbl.gov%2Fstatic%2Flogin.html&client_id="+clientId+"&scope=openid&nonce=whatever");	
-  $("#login").attr("href",orcidAuthUrl+"?response_type=token&redirect_uri=https%3A%2F%2Faimm.lbl.gov%2Fstatic%2Flogin.html&client_id="+clientId+"&scope=openid&&code_challenge_method=S256");	
+  $("#login").attr("href",orcidAuthUrl+"?response_type=token&redirect_uri=https%3A%2F%2Faimm.lbl.gov%2Fstatic%2Flogin.html&client_id="+clientId+"&scope=openid");	
   }
 });
 </script>


### PR DESCRIPTION
ORCID doesn't support PKCE https://github.com/ORCID/ORCID-Source/issues/5977

The code_challenge and code_challenge_method in the URL to ORCID are extraneous, I believe.

I accidently committed one commit to dev, but this follow up commit completes the removal of those fields.