### PR TITLE
fixed bug with ingest metadata channel, changed ingest return type to dicts

### DIFF
--- a/aimmdb/_tests/test_eli.py
+++ b/aimmdb/_tests/test_eli.py
@@ -27,9 +27,9 @@ def test_ingest():
     test_channels = ["transmission", "fluorescence", "reference"]
     mu_channels = ["mu_trans", "mu_fluor", "mu_ref"]
     for channel_data, tst_ch, mu_ch in zip(data, test_channels, mu_channels):
-        uid = channel_data["uid"]
-        assert uid == "d66dda13-d69c-4ca6-8fb7-76290ad71073"
         md = channel_data["metadata"]
+        uid = channel_data["uid"]
+        assert uid == md["_tiled"]["uid"] == "d66dda13-d69c-4ca6-8fb7-76290ad71073"
         channel = md["channel"]
         assert channel == tst_ch
         df = channel_data["data"]

--- a/aimmdb/_tests/test_eli.py
+++ b/aimmdb/_tests/test_eli.py
@@ -27,9 +27,9 @@ def test_ingest():
     test_channels = ["transmission", "fluorescence", "reference"]
     mu_channels = ["mu_trans", "mu_fluor", "mu_ref"]
     for channel_data, tst_ch, mu_ch in zip(data, test_channels, mu_channels):
-        md = channel_data["metadata"]
         uid = channel_data["uid"]
-        assert uid == md["_tiled"]["uid"] == "d66dda13-d69c-4ca6-8fb7-76290ad71073"
+        assert uid == "d66dda13-d69c-4ca6-8fb7-76290ad71073"
+        md = channel_data["metadata"]
         channel = md["channel"]
         assert channel == tst_ch
         df = channel_data["data"]

--- a/aimmdb/_tests/test_eli.py
+++ b/aimmdb/_tests/test_eli.py
@@ -1,5 +1,7 @@
 from aimmdb.ingest.eli import ingest, read_metadata_and_header
 from pathlib import Path
+import numpy as np
+import pandas as pd
 
 
 def test_read_md_and_header():
@@ -22,17 +24,18 @@ def test_read_md_and_header():
 def test_ingest():
     test_path = Path("aimmdb/_tests/eli_test_file.dat")
     data = ingest(test_path, return_uid=True)
-    for channel_data in data:
-        uid = channel_data[2]
+    test_channels = ["transmission", "fluorescence", "reference"]
+    mu_channels = ["mu_trans", "mu_fluor", "mu_ref"]
+    for channel_data, tst_ch, mu_ch in zip(data, test_channels, mu_channels):
+        uid = channel_data["uid"]
         assert uid == "d66dda13-d69c-4ca6-8fb7-76290ad71073"
-        md = channel_data[1]
+        md = channel_data["metadata"]
         channel = md["channel"]
-        assert channel in ["transmission", "fluorescence", "reference"]
-        df = channel_data[0]
+        assert channel == tst_ch
+        df = channel_data["data"]
         with open(test_path) as test_file:
             data_lines = [
                 line for line in test_file.readlines() if not line.startswith("#")
             ]
             assert df.shape[0] == len(data_lines)
-        mu_channels = ["mu_trans", "mu_fluor", "mu_ref"]
-        assert any([(mu in df.columns) for mu in mu_channels])
+        assert mu_ch in list(df.columns)

--- a/aimmdb/ingest/eli.py
+++ b/aimmdb/ingest/eli.py
@@ -82,7 +82,7 @@ def ingest(path, return_uid=False):
     md_trans = temp_md.copy()
 
     df_fluor = temp_data[["energy", "mu_fluor"]]
-    temp_md["channel"] = "fluoresence"
+    temp_md["channel"] = "fluorescence"
     md_fluor = temp_md.copy()
 
     df_ref = temp_data[["energy", "mu_ref"]]

--- a/aimmdb/ingest/eli.py
+++ b/aimmdb/ingest/eli.py
@@ -1,4 +1,3 @@
-from unittest.util import _MIN_DIFF_LEN
 import numpy as np
 import pandas as pd
 from pathlib import Path
@@ -44,6 +43,7 @@ def ingest(path, return_uid=False):
     Data is stored in .dat file which contains commented lines (denoted by #) with metadata,
     and columnated data below the metadata.
     Data columns should correspond to energy, i0, it, ir, iff, and aux channels.
+    DataFrame for aimmdb contains only energy and absorption coefficient (mu).
     There are several ways to calculate mu based on the mode of the measurement:
     - mu_trans = -ln(it/i0)
     - mu_fluor = iff/i0
@@ -60,7 +60,7 @@ def ingest(path, return_uid=False):
 
     Returns
     -------
-    tuple(tuple[DataFrame, dict[str, str]], tuple[DataFrame, dict[str, str]], tuple[DataFrame, dict[str, str]])
+    tuple({'data': DataFrame, 'metadata': dict}, {'data': DataFrame, 'metadata': dict}, {'data': DataFrame, 'metadata': dict})
         Database entries corresponding to the transmission, fluorescence, and reference channels.
 
     Other Parameters
@@ -78,27 +78,27 @@ def ingest(path, return_uid=False):
     temp_data["mu_ref"] = -np.log(temp_data["ir"] / temp_data["i0"])
 
     df_trans = temp_data[["energy", "mu_trans"]]
-    temp_md.update(channel="transmission")
-    md_trans = temp_md
+    temp_md["channel"] = "transmission"
+    md_trans = temp_md.copy()
 
     df_fluor = temp_data[["energy", "mu_fluor"]]
-    temp_md.update(channel="fluoresence")
-    md_fluor = temp_md
+    temp_md["channel"] = "fluoresence"
+    md_fluor = temp_md.copy()
 
     df_ref = temp_data[["energy", "mu_ref"]]
-    temp_md.update(channel="reference")
-    md_ref = temp_md
+    temp_md["channel"] = "reference"
+    md_ref = temp_md.copy()
 
     if return_uid:
         uid = temp_md["Scan.uid"]
         return (
-            (df_trans, md_trans, uid),
-            (df_fluor, md_fluor, uid),
-            (df_ref, md_ref, uid),
+            dict(data=df_trans, metadata=md_trans, uid=uid),
+            dict(data=df_fluor, metadata=md_fluor, uid=uid),
+            dict(data=df_ref, metadata=md_ref, uid=uid),
         )
     else:
         return (
-            (df_trans, md_trans),
-            (df_fluor, md_fluor),
-            (df_ref, md_ref),
+            dict(data=df_trans, metadata=md_trans),
+            dict(data=df_fluor, metadata=md_fluor),
+            dict(data=df_ref, metadata=md_ref),
         )

--- a/aimmdb/ingest/eli.py
+++ b/aimmdb/ingest/eli.py
@@ -37,13 +37,6 @@ def read_metadata_and_header(path):
     return metadata, header
 
 
-def add_tiled_uid(md: dict):
-    """Add "_tiled" key to metadata `dict`. This makes it easier to work with
-    postprocessing operators."""
-    md.update(_tiled={"uid": ""})
-    md["_tiled"]["uid"] = md["Scan.uid"]
-
-
 def ingest(path, return_uid=False):
     """Prepare scan data from Eli (ISS beamline) for entry into AIMMDB
 
@@ -78,7 +71,6 @@ def ingest(path, return_uid=False):
         piece of information that may be useful to store separately.
     """
     temp_md, hdr = read_metadata_and_header(path)
-    add_tiled_uid(temp_md)
 
     temp_data = pd.read_csv(path, delim_whitespace=True, comment="#", names=hdr.split())
     temp_data["mu_trans"] = -np.log(temp_data["it"] / temp_data["i0"])

--- a/aimmdb/ingest/eli.py
+++ b/aimmdb/ingest/eli.py
@@ -37,6 +37,13 @@ def read_metadata_and_header(path):
     return metadata, header
 
 
+def add_tiled_uid(md: dict):
+    """Add "_tiled" key to metadata `dict`. This makes it easier to work with
+    postprocessing operators."""
+    md.update(_tiled={"uid": ""})
+    md["_tiled"]["uid"] = md["Scan.uid"]
+
+
 def ingest(path, return_uid=False):
     """Prepare scan data from Eli (ISS beamline) for entry into AIMMDB
 
@@ -71,6 +78,7 @@ def ingest(path, return_uid=False):
         piece of information that may be useful to store separately.
     """
     temp_md, hdr = read_metadata_and_header(path)
+    add_tiled_uid(temp_md)
 
     temp_data = pd.read_csv(path, delim_whitespace=True, comment="#", names=hdr.split())
     temp_data["mu_trans"] = -np.log(temp_data["it"] / temp_data["i0"])


### PR DESCRIPTION
@x94carbone I was testing out the `ingest` function with the data Eli sent today, and I found a bug that the metadata `"channel"` key was always set to `"reference"`, instead of `"transmission"`, `"fluorescence"`, `"reference"`. 
Also I think it makes sense to change the return type of `ingest` to a tuple of dicts since the postprocessing operators are already setup to work on dicts with `"data"` and `"metadata"` keys.