### PR TITLE
Fix bug introduced in #35.

### DIFF
--- a/deploy/spin/docker/tiled/Dockerfile
+++ b/deploy/spin/docker/tiled/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/bluesky/tiled:0.1.0a74 as base
+FROM ghcr.io/bluesky/tiled:v0.1.0a74 as base
 
 FROM base as builder
 


### PR DESCRIPTION
#35 pinned the tiled base image on a tag does not exit because it omitted the leading `v` in the tag `v0.1.0a74`. I think the `Dockerfile` never worked:

```
$ docker build deploy/spin/docker/tiled/
Sending build context to Docker daemon  3.072kB
Step 1/9 : FROM ghcr.io/bluesky/tiled:0.1.0a74 as base
manifest unknown
```

Adding the `v` prefix, it works:

```
]$ docker build deploy/spin/docker/tiled/
Sending build context to Docker daemon  3.072kB
Step 1/9 : FROM ghcr.io/bluesky/tiled:v0.1.0a74 as base
v0.1.0a74: Pulling from bluesky/tiled
...
```